### PR TITLE
read-line function, and print function

### DIFF
--- a/src/clojure/core.clj
+++ b/src/clojure/core.clj
@@ -1,3 +1,6 @@
+(def *flush-on-newline* true)
+(def *print-readably* true)
+
 (def list (fn [& ls] ls))
 
 (defmacro defn [name args & body]
@@ -8,11 +11,27 @@
 (defn apply [f args]
   (lexical-eval (concat (list f) args)))
 
-(defn print [& more]
+(defn newline
+  []
+  (system-newline))
+
+(defn flush
+  []
+  (flush-stdout))
+
+(defn pr [& more]
   (print-string (apply str more)))
 
+(defn prn [& more]
+  (apply pr more)
+  (newline)
+  (flush))
+
+(defn print [& more]
+  (apply pr more))
+
 (defn println [& more]
-  (println-string (apply str more)))
+  (apply prn more))
 
 (defn inc [x]
   (+ x 1))
@@ -23,7 +42,7 @@
 (defmacro time [expr]
   (list (quote let) [(quote start) (quote (System_nanotime)) (quote ret) expr]
         (quote (do
-        (println (str "Elapsed time: " (_slash_ (- (System_nanotime) start) 1000000.0) " msecs"))
+        (println (str "Elapsed time: " (_slash_ (- (System_nanoTime) start) 1000000.0) " msecs"))
         ret))))
 
 (defn slurp [f & opts]

--- a/src/clojure/core.clj
+++ b/src/clojure/core.clj
@@ -40,7 +40,7 @@
   (- x 1))
 
 (defmacro time [expr]
-  (list (quote let) [(quote start) (quote (System_nanotime)) (quote ret) expr]
+  (list (quote let) [(quote start) (quote (System_nanoTime)) (quote ret) expr]
         (quote (do
         (println (str "Elapsed time: " (_slash_ (- (System_nanoTime) start) 1000000.0) " msecs"))
         ret))))

--- a/src/clojure/core.clj
+++ b/src/clojure/core.clj
@@ -8,8 +8,11 @@
 (defn apply [f args]
   (lexical-eval (concat (list f) args)))
 
-(defn println [& more]
+(defn print [& more]
   (print-string (apply str more)))
+
+(defn println [& more]
+  (println-string (apply str more)))
 
 (defn inc [x]
   (+ x 1))

--- a/src/clojure/core.clj
+++ b/src/clojure/core.clj
@@ -40,9 +40,9 @@
   (- x 1))
 
 (defmacro time [expr]
-  (list (quote let) [(quote start) (quote (System_nanoTime)) (quote ret) expr]
+  (list (quote let) [(quote start) (quote (System/nanoTime)) (quote ret) expr]
         (quote (do
-        (println (str "Elapsed time: " (_slash_ (- (System_nanoTime) start) 1000000.0) " msecs"))
+        (println (str "Elapsed time: " (_slash_ (- (System/nanoTime) start) 1000000.0) " msecs"))
         ret))))
 
 (defn slurp [f & opts]

--- a/src/clojure_std.rs
+++ b/src/clojure_std.rs
@@ -1,2 +1,3 @@
-pub(crate) mod thread;
-pub(crate) mod time;
+pub (crate) mod thread;
+pub (crate) mod time;
+pub (crate) mod env;

--- a/src/clojure_std/env.rs
+++ b/src/clojure_std/env.rs
@@ -1,0 +1,35 @@
+use crate::error_message;
+use crate::ifn::IFn;
+use crate::value::{ToValue, Value};
+use std::rc::Rc;
+
+use std::env;
+use crate::type_tag::TypeTag;
+
+/// provides a function to return env variables
+/// similair to Clojure (System/getenv [key])
+#[derive(Debug, Clone)]
+pub struct GetEnvFn {}
+impl ToValue for GetEnvFn {
+    fn to_value(&self) -> Value {
+        Value::IFn(Rc::new(self.clone()))
+    }
+}
+
+impl IFn for GetEnvFn {
+    fn invoke(&self, args: Vec<Rc<Value>>) -> Value {
+        if args.len() == 1 {
+            match args.get(0).unwrap().to_value() {
+                Value::String(key) => {
+                    match env::var(key) {
+                        Ok(val) => Value::String(val),
+                        Err(_) => Value::Nil
+                    }
+                }
+                _a => error_message::type_mismatch(TypeTag::String, &_a)
+            }
+        } else {
+            return error_message::wrong_arg_count(1, args.len());
+        }
+    }
+}

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -199,6 +199,8 @@ impl Environment {
         let do_macro = rust_core::DoMacro {};
         let concat_fn = rust_core::ConcatFn {};
         let print_string_fn = rust_core::PrintStringFn {};
+        let println_string_fn = rust_core::PrintlnStringFn {};
+        let read_line_fn = rust_core::ReadLineFn {};
         let assoc_fn = rust_core::AssocFn {};
 
         // rust implementations of core functions
@@ -277,6 +279,11 @@ impl Environment {
             Symbol::intern("print-string"),
             print_string_fn.to_rc_value(),
         );
+        environment.insert(
+            Symbol::intern("println-string"),
+            println_string_fn.to_rc_value(),
+        );
+        environment.insert(Symbol::intern("read-line"), read_line_fn.to_rc_value());
 
         //
         // Read in clojure.core

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -244,15 +244,24 @@ impl Environment {
         environment.insert(Symbol::intern("defmacro"), defmacro_macro.to_rc_value());
         environment.insert(Symbol::intern("eval"), eval_fn.to_rc_value());
 
-        // Thread namespace TODO / instead of _
-        environment.insert(
-            Symbol::intern("Thread_sleep"),
-            thread_sleep_fn.to_rc_value(),
-        );
+        // Thread namespace
+		environment.insert_into_namespace(
+			&Symbol::intern("Thread"),
+			Symbol::intern("sleep"),
+			thread_sleep_fn.to_rc_value()
+		);
 
-        environment.insert(Symbol::intern("System_nanoTime"), nanotime_fn.to_rc_value());
-
-        environment.insert(Symbol::intern("System_getenv"), get_env_fn.to_rc_value());
+		// System namespace
+		environment.insert_into_namespace(
+			&Symbol::intern("System"),
+			Symbol::intern("nanoTime"),
+			nanotime_fn.to_rc_value()
+		);
+		environment.insert_into_namespace(
+			&Symbol::intern("System"),
+			Symbol::intern("getenv"),
+			get_env_fn.to_rc_value()
+		);
 
         // core.clj wraps calls to the rust implementations
         // @TODO add this to clojure.rs.core namespace as clojure.rs.core/slurp

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -36,14 +36,13 @@ impl Repl {
         loop {
             print!("{}=> ",self.environment.get_current_namespace_name());
             let _ = io::stdout().flush();
-            let mut next = Value::Nil;
 
-            // a scope for stdin to be released for providing input for function
-            {
+            let next = {
                 let mut stdin_reader = stdin.lock();
                 // Read
-                next = Repl::read(&mut stdin_reader);
-            }
+                Repl::read(&mut stdin_reader)
+                // Release stdin.lock
+            };
 
             // Eval
             let evaled_next = self.eval(&next);

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -36,9 +36,15 @@ impl Repl {
         loop {
             print!("{}=> ",self.environment.get_current_namespace_name());
             let _ = io::stdout().flush();
+            let mut next = Value::Nil;
 
-            // Read
-            let next = Repl::read(&mut stdin_reader);
+            // a scope for stdin to be released for providing input for function
+            {
+                let mut stdin_reader = stdin.lock();
+                // Read
+                next = Repl::read(&mut stdin_reader);
+            }
+
             // Eval
             let evaled_next = self.eval(&next);
             // Print

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -31,7 +31,6 @@ impl Repl {
     }
     pub fn run(&self) {
         let stdin = io::stdin();
-        let mut stdin_reader = stdin.lock();
 
         loop {
             print!("{}=> ",self.environment.get_current_namespace_name());

--- a/src/rust_core.rs
+++ b/src/rust_core.rs
@@ -44,12 +44,17 @@ pub(crate) mod assoc;
 pub use self::assoc::*;
 
 // input and output
+pub(crate) mod system_newline;
+pub use self::system_newline::*;
+pub(crate) mod flush_stdout;
+pub use self::flush_stdout::*;
 pub(crate) mod print_string;
 pub use self::print_string::*;
 pub(crate) mod string_print;
 pub use self::string_print::*;
 pub(crate) mod read_line;
 pub use self::read_line::*;
+
 
 // other
 pub(crate) mod slurp;

--- a/src/rust_core.rs
+++ b/src/rust_core.rs
@@ -48,6 +48,8 @@ pub(crate) mod print_string;
 pub use self::print_string::*;
 pub(crate) mod string_print;
 pub use self::string_print::*;
+pub(crate) mod read_line;
+pub use self::read_line::*;
 
 // other
 pub(crate) mod slurp;

--- a/src/rust_core/_divide_.rs
+++ b/src/rust_core/_divide_.rs
@@ -16,7 +16,7 @@ impl ToValue for DivideFn {
 impl IFn for DivideFn {
     fn invoke(&self, args: Vec<Rc<Value>>) -> Value {
         match args.len() {
-            0 => error_message::wrong_arg_count(1,args.len()),
+            0 => error_message::zero_arg_count(args.len()),
             1 => {
                 let val = args.get(0).unwrap().to_value();
                 match val {
@@ -71,7 +71,7 @@ mod tests {
         use std::rc::Rc;
 
         #[test]
-        fn divide_without_arguments_returns_one() {
+        fn divide_without_arguments_returns_error() {
             let divide = DivideFn {};
             let args = vec![];
             assert_eq!(

--- a/src/rust_core/_divide_.rs
+++ b/src/rust_core/_divide_.rs
@@ -76,7 +76,7 @@ mod tests {
             let args = vec![];
             assert_eq!(
                 Value::Condition(String::from(
-                    "Wrong number of arguments given to function (Given: 0, Expected: 1)"
+                    "Wrong number of arguments given to function (Given: 0)"
                 )),
                 divide.invoke(args)
             );

--- a/src/rust_core/flush_stdout.rs
+++ b/src/rust_core/flush_stdout.rs
@@ -11,24 +11,18 @@ use std::io::{Read, Write};
 /// Read a line from stdin TODO: should be aware of *in*
 /// (defn read-line [])
 #[derive(Debug, Clone)]
-pub struct ReadLineFn {}
-impl ToValue for ReadLineFn {
+pub struct FlushStdoutFn {}
+impl ToValue for FlushStdoutFn {
     fn to_value(&self) -> Value {
         Value::IFn(Rc::new(self.clone()))
     }
 }
-impl IFn for ReadLineFn {
+impl IFn for FlushStdoutFn {
     fn invoke(&self, args: Vec<Rc<Value>>) -> Value {
         if args.len() != 0 {
             return error_message::wrong_arg_count(0, args.len())
         }
-        let mut input = String::new();
-        match io::stdin().read_line(&mut input) {
-            Ok(_) => {
-                input.pop();
-                Value::String(input)
-            },
-            Err(error) => error_message::generic_err(Box::try_from(error).unwrap())
-        }
+        io::stdout().flush();
+        Value::Nil
     }
 }

--- a/src/rust_core/print_string.rs
+++ b/src/rust_core/print_string.rs
@@ -5,7 +5,26 @@ use std::rc::Rc;
 use crate::error_message;
 
 /// Primitive printing function;
-/// (defn print-string [string] .. prints single string .. )
+/// (defn println-string [string] .. prints single string with linebreak.. )
+#[derive(Debug, Clone)]
+pub struct PrintlnStringFn {}
+impl ToValue for PrintlnStringFn {
+    fn to_value(&self) -> Value {
+        Value::IFn(Rc::new(self.clone()))
+    }
+}
+impl IFn for PrintlnStringFn {
+    fn invoke(&self, args: Vec<Rc<Value>>) -> Value {
+        if args.len() != 1 {
+            return error_message::wrong_arg_count(1, args.len())
+        }
+        println!("{}", args.get(0).unwrap().to_string());
+        Value::Nil
+    }
+}
+
+/// Primitive printing function;
+/// (defn print-string [string] .. prints single string without linebreak.. )
 #[derive(Debug, Clone)]
 pub struct PrintStringFn {}
 impl ToValue for PrintStringFn {
@@ -18,7 +37,7 @@ impl IFn for PrintStringFn {
         if args.len() != 1 {
             return error_message::wrong_arg_count(1, args.len());
         }
-        println!("{}", args.get(0).unwrap().to_string());
+        print!("{}", args.get(0).unwrap().to_string());
         Value::Nil
     }
 }

--- a/src/rust_core/read_line.rs
+++ b/src/rust_core/read_line.rs
@@ -22,11 +22,13 @@ impl IFn for ReadLineFn {
         if args.len() != 0 {
             return error_message::wrong_arg_count(0, args.len())
         }
-        
         let mut input = String::new();
         io::stdout().flush();
         match io::stdin().read_line(&mut input) {
-            Ok(_) => Value::String(input),
+            Ok(_) => {
+                input.pop();
+                Value::String(input)
+            },
             Err(error) => error_message::generic_err(Box::try_from(error).unwrap())
         }
     }

--- a/src/rust_core/read_line.rs
+++ b/src/rust_core/read_line.rs
@@ -22,8 +22,7 @@ impl IFn for ReadLineFn {
         if args.len() != 0 {
             return error_message::wrong_arg_count(0, args.len())
         }
-
-        //io::stdout().flush();
+        
         let mut input = String::new();
         io::stdout().flush();
         match io::stdin().read_line(&mut input) {

--- a/src/rust_core/read_line.rs
+++ b/src/rust_core/read_line.rs
@@ -1,0 +1,34 @@
+use crate::ifn::IFn;
+use crate::value::{Value, ToValue, Evaluable};
+use std::rc::Rc;
+
+use std::io;
+
+use crate::error_message;
+use nom::lib::std::convert::TryFrom;
+use std::io::{Read, Write};
+
+/// Read a line from stdin
+/// (defn read-line [])
+#[derive(Debug, Clone)]
+pub struct ReadLineFn {}
+impl ToValue for ReadLineFn {
+    fn to_value(&self) -> Value {
+        Value::IFn(Rc::new(self.clone()))
+    }
+}
+impl IFn for ReadLineFn {
+    fn invoke(&self, args: Vec<Rc<Value>>) -> Value {
+        if args.len() != 0 {
+            return error_message::wrong_arg_count(0, args.len())
+        }
+
+        //io::stdout().flush();
+        let mut input = String::new();
+        io::stdout().flush();
+        match io::stdin().read_line(&mut input) {
+            Ok(_) => Value::String(input),
+            Err(error) => error_message::generic_err(Box::try_from(error).unwrap())
+        }
+    }
+}

--- a/src/rust_core/system_newline.rs
+++ b/src/rust_core/system_newline.rs
@@ -4,21 +4,22 @@ use std::rc::Rc;
 
 use crate::error_message;
 
-/// Primitive printing function; TODO: should be aware of *out*
+/// Prints system newline, `\n` in rust on all platforms to stdout
+/// TODO: should be aware of *out*
 /// (defn print-string [string] .. prints single string without linebreak.. )
 #[derive(Debug, Clone)]
-pub struct PrintStringFn {}
-impl ToValue for PrintStringFn {
+pub struct SystemNewlineFn {}
+impl ToValue for SystemNewlineFn {
     fn to_value(&self) -> Value {
         Value::IFn(Rc::new(self.clone()))
     }
 }
-impl IFn for PrintStringFn {
+impl IFn for SystemNewlineFn {
     fn invoke(&self, args: Vec<Rc<Value>>) -> Value {
-        if args.len() != 1 {
-            return error_message::wrong_arg_count(1, args.len());
+        if args.len() != 0 {
+            return error_message::wrong_arg_count(0, args.len());
         }
-        print!("{}", args.get(0).unwrap().to_string());
+        print!("\n");
         Value::Nil
     }
 }


### PR DESCRIPTION
```clojure
user=> (do (print "What is your name? ") (let [s (read-line)] (println "Hello, " s)))
What is your name? Erkki
Hello, Erkki
nil
user=>
```

includes "compatible interface" to clojure core
* flush
* new-line
* pr
* prn
* print
* println

variables (required if & truthiness and some other glue to work, but is prepared for pr, prn, print and println)
*flush-on-newline*
*print-readable* 

Also:
* changed nanotime -> nanoTime to match clojure symbol name
* System/getenv to get env variables the same way as in clojure
* fixed name space for Thread and System
* fix broken unit test for divide

