### PR TITLE
introduces type and deftype-rs for defining types and interop

### DIFF
--- a/src/clojure/clojure_interop.clj
+++ b/src/clojure/clojure_interop.clj
@@ -1,0 +1,57 @@
+(ns clojure.interop)
+
+;; Interop for reading clojure.core
+
+;;;
+;    Types
+;;
+
+;; We define 'Classes' with aliases so that we have types
+;; the first one in a group is the (only or) clojureRS type name
+;; and the type names following the first are aliases for interop
+;; (when available)
+
+(def rust.std.i32 (clojure.interop/deftype-rs "rust.std.i32"))
+(def java.lang.Long rust.std.i32)
+(def java.lang.Integer rust.std.i32)
+(def Integer rust.std.i32)
+(def Long rust.std.i32)
+
+(def rust.std.bool (clojure.interop/deftype-rs "rust.std.bool"))
+(def java.lang.Boolean rust.std.bool)
+(def Boolean rust.std.bool)
+
+(def rust.std.f64 (clojure.interop/deftype-rs "rust.std.f64"))
+(def java.lang.Double rust.std.f64)
+(def Double rust.std.f64)
+
+(def rust.std.string.String (clojure.interop/deftype-rs "rust.std.string.String"))
+(def java.lang.String rust.std.string.String)
+(def String rust.std.string.String)
+
+(def clojure.lang.Symbol (clojure.interop/deftype-rs "clojure.lang.Symbol"))
+
+(def clojure.lang.Class (clojure.interop/deftype-rs "clojure.lang.Class"))
+
+(def clojure.lang.Keyword (clojure.interop/deftype-rs "clojure.lang.Keyword"))
+
+(def clojure.lang.IFn (clojure.interop/deftype-rs "clojure.lang.IFn"))
+(def clojure.lang.Function clojure.lang.IFn)
+
+(def clojure.lang.Condition (clojure.interop/deftype-rs "clojure.lang.Condition"))
+
+(def clojure.lang.PersistentList (clojure.interop/deftype-rs "clojure.lang.PersistentList"))
+
+(def clojure.lang.PersistentVector (clojure.interop/deftype-rs "clojure.lang.PersistentVector"))
+
+(def clojure.lang.PersistentArrayMap (clojure.interop/deftype-rs "clojure.lang.PersistentArrayMap"))
+(def clojure.lang.PersistentListMap clojure.lang.PersistentArrayMap)
+
+(def clojure.lang.Macro (clojure.interop/deftype-rs "clojure.lang.Macro"))
+
+(def clojure.lang.ISeq (clojure.interop/deftype-rs "clojure.lang.ISeq"))
+
+(def clojure.lang.Nil (clojure.interop/deftype-rs "clojure.lang.Nil"))
+
+(def rust.regex (clojure.interop/deftype-rs "rust.regex"))
+(def java.util.regex.Pattern rust.regex)

--- a/src/clojure/core.clj
+++ b/src/clojure/core.clj
@@ -1,3 +1,6 @@
+(ns clojure.core)
+(refer 'clojure.interop)
+
 (def *flush-on-newline* true)
 (def *print-readably* true)
 

--- a/src/clojure/string.clj
+++ b/src/clojure/string.clj
@@ -1,7 +1,7 @@
-"clojure.string"
+(ns clojure.string)
 
 "TODO : some special syntax required because of missing require"
 
-(def clojure.string/split-lines
+(def split-lines
   (fn [s]
-    (clojure.string/split s #"\r?\n")))
+    (split s #"\r?\n")))

--- a/src/clojure_string/blank_qmark_.rs
+++ b/src/clojure_string/blank_qmark_.rs
@@ -33,7 +33,6 @@ impl IFn for BlankFn {
                         );
                     }
                 }
-                Value::String(s) => Value::String(s.chars().rev().collect()),
                 _a => error_message::type_mismatch(TypeTag::String, &_a.to_value()),
             }
         }

--- a/src/error_message.rs
+++ b/src/error_message.rs
@@ -1,7 +1,6 @@
 use crate::type_tag::TypeTag;
 use crate::value::Value;
 use std::error::Error;
-use std::fmt;
 
 pub fn type_mismatch(expected: TypeTag, got: &Value) -> Value {
     Value::Condition(format!(

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -11,7 +11,7 @@
 use nom::combinator::verify;
 use nom::{
     branch::alt, bytes::complete::tag, combinator::opt, map, sequence::preceded, take_until,
-    terminated, AsChar, Err::Incomplete, IResult,
+    Err::Incomplete, IResult,
 };
 
 use crate::keyword::Keyword;
@@ -23,8 +23,6 @@ use crate::symbol::Symbol;
 use crate::value::{ToValue, Value};
 use std::rc::Rc;
 
-use nom::Err::Error;
-use std::borrow::Borrow;
 use std::io::BufRead;
 //
 // Note; the difference between ours 'parsers'
@@ -148,7 +146,7 @@ fn is_period_char(chr: char) -> bool {
 ///
 /// Clojure defines a whitespace as either a comma or an unicode whitespace.
 fn is_clojure_whitespace(c: char) -> bool {
-    c.is_whitespace() || c == ',' 
+    c.is_whitespace() || c == ','
 }
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //     End predicates
@@ -169,16 +167,16 @@ fn consume_clojure_whitespaces_parser(input: &str) -> IResult<&str, ()> {
 
     named!(whitespace_parser<&str,()>,
            value!((),
-               many0!(alt!(comment_parser | 
+               many0!(alt!(comment_parser |
                            take_while1!(is_clojure_whitespace))))
     );
 
     named!(no_whitespace_parser<&str,()>, value!((),tag!("")));
 
-    // @TODO rename / check that all parsers are consistent? 
+    // @TODO rename / check that all parsers are consistent?
     named!(parser<&str,()>,
            // Because 'whitespace_parser' loops, we cannot include the case where there's no whitespace at all in
-           // its definition -- nom wouldn't allow it, as it would loop forever consuming no whitespace 
+           // its definition -- nom wouldn't allow it, as it would loop forever consuming no whitespace
            // So instead, we eat up all the whitespace first, and then use the no_whitespace_parser as our sort-of
            // base-case after
            alt!(whitespace_parser | no_whitespace_parser)
@@ -560,12 +558,15 @@ pub fn read<R: BufRead>(reader: &mut R) -> Value {
     // loop over and ask for more lines, accumulating them in input_buffer until we can read
     loop {
         let maybe_line = reader.by_ref().lines().next();
-        
+
         match maybe_line {
             Some(Err(e)) => return Value::Condition(format!("Reader error: {}", e)),
             // `lines` does not include \n,  but \n is part of the whitespace given to the reader
-            // (and is important for reading comments) so we will push a newline as well 
-            Some(Ok(line)) => { input_buffer.push_str(&line); input_buffer.push_str("\n"); },
+            // (and is important for reading comments) so we will push a newline as well
+            Some(Ok(line)) => {
+                input_buffer.push_str(&line);
+                input_buffer.push_str("\n");
+            }
             None => {
                 return Value::Condition(String::from("Tried to read empty stream; unexpected EOF"))
             }

--- a/src/rust_core.rs
+++ b/src/rust_core.rs
@@ -1,9 +1,16 @@
 // This module will hold core function and macro primitives that aren't special cases
 // (like the quote macro, or let), and can't be implemented in clojure itself
 
+// rust core special functionality, for java interop
+pub(crate) mod deftype_rs;
+pub use self::deftype_rs::*;
+
 // language core functions
 pub(crate) mod eval;
 pub use self::eval::*;
+
+pub(crate) mod type_fn;
+pub use self::type_fn::*;
 
 // macros
 pub(crate) mod do_macro;

--- a/src/rust_core/deftype_rs.rs
+++ b/src/rust_core/deftype_rs.rs
@@ -1,0 +1,49 @@
+use crate::error_message;
+use crate::ifn::IFn;
+use crate::type_tag::{type_tag_for_name, TypeTag};
+use crate::value::{ToValue, Value};
+use std::rc::Rc;
+
+/// deftype-rs, to define a class in clojurers
+/// For providing interoperability currently
+/// example (deftype-rs "java.lang.String") returns a Value::Class(String) (does not intern)
+/// TODO: definitely NOT the same as clojure.core/deftype
+#[derive(Debug, Clone)]
+pub struct DeftypeRsFn {}
+impl ToValue for DeftypeRsFn {
+    fn to_value(&self) -> Value {
+        Value::IFn(Rc::new(self.clone()))
+    }
+}
+impl IFn for DeftypeRsFn {
+    fn invoke(&self, args: Vec<Rc<Value>>) -> Value {
+        if args.len() != 1 {
+            return error_message::wrong_arg_count(1, args.len());
+        }
+
+        match args.get(0).unwrap().to_value() {
+            Value::String(s) => return Value::Class(type_tag_for_name(&s)),
+            _val => error_message::type_mismatch(TypeTag::String, &_val),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod deftype_rs_tests {
+
+        use crate::ifn::IFn;
+        use crate::rust_core::DeftypeRsFn;
+        use crate::type_tag::TypeTag;
+        use crate::value::Value;
+        use std::rc::Rc;
+
+        #[test]
+        fn deftype() {
+            let deftype_rs = DeftypeRsFn {};
+            let s = "rust.std.string.String";
+            let args = vec![Rc::new(Value::String(String::from(s)))];
+            assert_eq!(Value::Class(TypeTag::String), deftype_rs.invoke(args));
+        }
+    }
+}

--- a/src/rust_core/first.rs
+++ b/src/rust_core/first.rs
@@ -1,8 +1,7 @@
 use crate::error_message;
 use crate::ifn::IFn;
 use crate::iterable::Iterable;
-use crate::persistent_list::PersistentList;
-use crate::protocol::{Protocol, ProtocolCastable};
+use crate::protocol::ProtocolCastable;
 use crate::type_tag::TypeTag;
 use crate::value::{ToValue, Value};
 use std::rc::Rc;

--- a/src/rust_core/flush_stdout.rs
+++ b/src/rust_core/flush_stdout.rs
@@ -21,7 +21,7 @@ impl IFn for FlushStdoutFn {
         if args.len() != 0 {
             return error_message::wrong_arg_count(0, args.len());
         }
-        io::stdout().flush();
+        let _ = io::stdout().flush();
         Value::Nil
     }
 }

--- a/src/rust_core/load_file.rs
+++ b/src/rust_core/load_file.rs
@@ -30,7 +30,7 @@ impl IFn for LoadFileFn {
             ))
         } else if let Value::String(file) = &**args.get(0).unwrap() {
             // @TODO clean this
-            Repl::new(Rc::clone(&self.enclosing_environment)).try_eval_file(file);
+            let _ = Repl::new(Rc::clone(&self.enclosing_environment)).try_eval_file(file);
             //@TODO remove this placeholder value, return last value evaluated in try_eval_file
             Value::Nil
         } else {

--- a/src/rust_core/more.rs
+++ b/src/rust_core/more.rs
@@ -2,7 +2,7 @@ use crate::error_message;
 use crate::ifn::IFn;
 use crate::iterable::Iterable;
 use crate::persistent_list::PersistentList;
-use crate::protocol::{Protocol, ProtocolCastable};
+use crate::protocol::ProtocolCastable;
 use crate::type_tag::TypeTag;
 use crate::value::{ToValue, Value};
 use std::rc::Rc;

--- a/src/rust_core/refer.rs
+++ b/src/rust_core/refer.rs
@@ -2,7 +2,7 @@ use crate::environment::Environment;
 use crate::error_message;
 use crate::ifn::IFn;
 use crate::keyword::Keyword;
-use crate::persistent_vector::{ToPersistentVectorIter};
+use crate::persistent_vector::ToPersistentVectorIter;
 use crate::symbol::Symbol;
 use crate::type_tag::TypeTag;
 use crate::util::IsOdd;

--- a/src/rust_core/second.rs
+++ b/src/rust_core/second.rs
@@ -1,8 +1,7 @@
 use crate::error_message;
 use crate::ifn::IFn;
 use crate::iterable::Iterable;
-use crate::persistent_list::PersistentList;
-use crate::protocol::{Protocol, ProtocolCastable};
+use crate::protocol::ProtocolCastable;
 use crate::type_tag::TypeTag;
 use crate::value::{ToValue, Value};
 use std::rc::Rc;

--- a/src/rust_core/type_fn.rs
+++ b/src/rust_core/type_fn.rs
@@ -1,0 +1,48 @@
+use crate::error_message;
+use crate::ifn::IFn;
+use crate::value::{ToValue, Value};
+use std::rc::Rc;
+
+/// Returns type for x
+/// example (type x)
+#[derive(Debug, Clone)]
+pub struct TypeFn {}
+impl ToValue for TypeFn {
+    fn to_value(&self) -> Value {
+        Value::IFn(Rc::new(self.clone()))
+    }
+}
+impl IFn for TypeFn {
+    fn invoke(&self, args: Vec<Rc<Value>>) -> Value {
+        if args.len() != 1 {
+            return error_message::wrong_arg_count(1, args.len());
+        }
+
+        match args.get(0).unwrap().to_value() {
+            Value::Condition(s) => Value::Condition(s),
+            _any => {
+                return Value::Class(_any.type_tag());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod type_fn_tests {
+
+        use crate::ifn::IFn;
+        use crate::rust_core::TypeFn;
+        use crate::type_tag::TypeTag;
+        use crate::value::Value;
+        use std::rc::Rc;
+
+        #[test]
+        fn type_fn_test() {
+            let type_fn = TypeFn {};
+            let s = "whatever";
+            let args = vec![Rc::new(Value::String(String::from(s)))];
+            assert_eq!(Value::Class(TypeTag::String), type_fn.invoke(args));
+        }
+    }
+}

--- a/src/type_tag.rs
+++ b/src/type_tag.rs
@@ -6,6 +6,7 @@ pub enum TypeTag {
     F64,
     Boolean,
     Symbol,
+    Class,
     Keyword,
     IFn,
     Condition,
@@ -30,8 +31,9 @@ impl fmt::Display for TypeTag {
             Boolean => std::string::String::from("rust.std.bool"),
             F64 => std::string::String::from("rust.std.f64"),
             Symbol => std::string::String::from("clojure.lang.Symbol"),
+            Class => std::string::String::from("clojure.lang.Class"),
             Keyword => std::string::String::from("clojure.lang.Keyword"),
-            IFn => std::string::String::from("clojure.lang.Function"),
+            IFn => std::string::String::from("clojure.lang.IFn"),
             Condition => std::string::String::from("clojure.lang.Condition"),
             PersistentList => std::string::String::from("clojure.lang.PersistentList"),
             PersistentVector => std::string::String::from("clojure.lang.PersistentVector"),
@@ -45,4 +47,27 @@ impl fmt::Display for TypeTag {
         };
         write!(f, "{}", str)
     }
+}
+
+pub fn type_tag_for_name(type_tag_name: &str) -> TypeTag {
+    return match type_tag_name {
+        "rust.std.i32" => return TypeTag::I32,
+        "rust.std.bool" => TypeTag::Boolean,
+        "rust.std.f64" => TypeTag::F64,
+        "clojure.lang.Symbol" => TypeTag::Symbol,
+        "clojure.lang.Class" => TypeTag::Class,
+        "clojure.lang.Keyword" => TypeTag::Keyword,
+        "clojure.lang.Function" => TypeTag::IFn,
+        "clojure.lang.Condition" => TypeTag::Condition,
+        "clojure.lang.PersistentList" => TypeTag::PersistentList,
+        "clojure.lang.PersistentVector" => TypeTag::PersistentVector,
+        "clojure.lang.PersistentListMap" => TypeTag::PersistentListMap,
+        "clojure.lang.Macro" => TypeTag::Macro,
+        "rust.std.string.String" => TypeTag::String,
+        "clojure.lang.Integer" => TypeTag::Integer,
+        "clojure.lang.ISeq" => TypeTag::ISeq,
+        "clojure.lang.Nil" => TypeTag::Nil,
+        "rust.regex" => TypeTag::Pattern,
+        _ => TypeTag::Nil,
+    };
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -32,6 +32,7 @@ pub enum Value {
     F64(f64),
     Boolean(bool),
     Symbol(Symbol),
+    Class(TypeTag),
     Keyword(Keyword),
     IFn(Rc<dyn IFn>),
     //
@@ -75,6 +76,7 @@ impl PartialEq for Value {
             (F64(d), F64(d2)) => d == d2,
             (Boolean(b), Boolean(b2)) => b == b2,
             (Symbol(sym), Symbol(sym2)) => sym == sym2,
+            (Class(t), Class(t2)) => t.to_string() == t2.to_string(),
             (Keyword(kw), Keyword(kw2)) => kw == kw2,
             // Equality not defined on functions, similar to Clojure
             // Change this perhaps? Diverge?
@@ -118,6 +120,7 @@ impl Hash for Value {
             F64(d) => d.to_value().hash(state),
             Boolean(b) => b.hash(state),
             Symbol(sym) => sym.hash(state),
+            Class(t) => t.to_string().hash(state),
             Keyword(kw) => kw.hash(state),
             IFn(_) => {
                 let mut rng = rand::thread_rng();
@@ -158,6 +161,7 @@ impl fmt::Display for Value {
             F64(val) => val.to_string(),
             Boolean(val) => val.to_string(),
             Symbol(sym) => sym.to_string(),
+            Class(t) => t.to_string(),
             Keyword(kw) => kw.to_string(),
             IFn(_) => std::string::String::from("#function[]"),
             LexicalEvalFn => std::string::String::from("#function[lexical-eval*]"),
@@ -202,6 +206,7 @@ impl Value {
             Value::F64(_) => TypeTag::F64,
             Value::Boolean(_) => TypeTag::Boolean,
             Value::Symbol(_) => TypeTag::Symbol,
+            Value::Class(_) => TypeTag::Class,
             Value::Keyword(_) => TypeTag::Keyword,
             Value::IFn(_) => TypeTag::IFn,
             Value::LexicalEvalFn => TypeTag::IFn,


### PR DESCRIPTION
new functions, for a base of interoperability

* Value::Class that holds the type
* type - to resolve the type of an argument
* deftype-rs - to define a type for interop
* unit tests for above 
* removed also some unnecessary imports, formatting updates
* use ns and refer correctly in clj files
* also sets the default namespace in repl to user
