### PR TITLE
lt, gt, lte, gte with tests

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -307,6 +307,10 @@ impl Environment {
         let ns_macro = rust_core::NsMacro::new(Rc::clone(&environment));
         let load_file_fn = rust_core::LoadFileFn::new(Rc::clone(&environment));
         let refer_fn = rust_core::ReferFn::new(Rc::clone(&environment));
+        let lt_fn = rust_core::lt::LtFn {};
+        let gt_fn = rust_core::gt::GtFn {};
+        let lte_fn = rust_core::lte::LteFn {};
+        let gte_fn = rust_core::gte::GteFn {};
         // @TODO after we merge this with all the other commits we have,
         //       just change all the `insert`s here to use insert_in_namespace
         //       I prefer explicity and the non-dependence-on-environmental-factors
@@ -325,6 +329,30 @@ impl Environment {
         environment.insert(Symbol::intern("fn"), fn_macro.to_rc_value());
         environment.insert(Symbol::intern("defmacro"), defmacro_macro.to_rc_value());
         environment.insert(Symbol::intern("eval"), eval_fn.to_rc_value());
+
+        // Interop to read real clojure.core
+        environment.insert_into_namespace(
+            &Symbol::intern("clojure.interop"),
+            Symbol::intern("lt"),
+            lt_fn.to_rc_value(),
+        );
+
+        environment.insert_into_namespace(
+            &Symbol::intern("clojure.interop"),
+            Symbol::intern("gt"),
+            gt_fn.to_rc_value(),
+        );
+        environment.insert_into_namespace(
+            &Symbol::intern("clojure.interop"),
+            Symbol::intern("lte"),
+            lte_fn.to_rc_value(),
+        );
+
+        environment.insert_into_namespace(
+            &Symbol::intern("clojure.interop"),
+            Symbol::intern("gte"),
+            gte_fn.to_rc_value(),
+        );
 
         // Thread namespace
         environment.insert_into_namespace(

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -331,28 +331,12 @@ impl Environment {
         environment.insert(Symbol::intern("eval"), eval_fn.to_rc_value());
 
         // Interop to read real clojure.core
-        environment.insert_into_namespace(
-            &Symbol::intern("clojure.interop"),
-            Symbol::intern("lt"),
-            lt_fn.to_rc_value(),
-        );
+        environment.insert(Symbol::intern("lt"),lt_fn.to_rc_value());
 
-        environment.insert_into_namespace(
-            &Symbol::intern("clojure.interop"),
-            Symbol::intern("gt"),
-            gt_fn.to_rc_value(),
-        );
-        environment.insert_into_namespace(
-            &Symbol::intern("clojure.interop"),
-            Symbol::intern("lte"),
-            lte_fn.to_rc_value(),
-        );
+        environment.insert(Symbol::intern("gt"),gt_fn.to_rc_value());
+        environment.insert(Symbol::intern("lte"),lte_fn.to_rc_value());
 
-        environment.insert_into_namespace(
-            &Symbol::intern("clojure.interop"),
-            Symbol::intern("gte"),
-            gte_fn.to_rc_value(),
-        );
+        environment.insert(Symbol::intern("gte"),gte_fn.to_rc_value());
 
         // Thread namespace
         environment.insert_into_namespace(

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -148,7 +148,7 @@ fn is_period_char(chr: char) -> bool {
 ///
 /// Clojure defines a whitespace as either a comma or an unicode whitespace.
 fn is_clojure_whitespace(c: char) -> bool {
-    c.is_whitespace() || c == ',' 
+    c.is_whitespace() || c == ','
 }
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //     End predicates
@@ -169,16 +169,16 @@ fn consume_clojure_whitespaces_parser(input: &str) -> IResult<&str, ()> {
 
     named!(whitespace_parser<&str,()>,
            value!((),
-               many0!(alt!(comment_parser | 
+               many0!(alt!(comment_parser |
                            take_while1!(is_clojure_whitespace))))
     );
 
     named!(no_whitespace_parser<&str,()>, value!((),tag!("")));
 
-    // @TODO rename / check that all parsers are consistent? 
+    // @TODO rename / check that all parsers are consistent?
     named!(parser<&str,()>,
            // Because 'whitespace_parser' loops, we cannot include the case where there's no whitespace at all in
-           // its definition -- nom wouldn't allow it, as it would loop forever consuming no whitespace 
+           // its definition -- nom wouldn't allow it, as it would loop forever consuming no whitespace
            // So instead, we eat up all the whitespace first, and then use the no_whitespace_parser as our sort-of
            // base-case after
            alt!(whitespace_parser | no_whitespace_parser)
@@ -560,12 +560,15 @@ pub fn read<R: BufRead>(reader: &mut R) -> Value {
     // loop over and ask for more lines, accumulating them in input_buffer until we can read
     loop {
         let maybe_line = reader.by_ref().lines().next();
-        
+
         match maybe_line {
             Some(Err(e)) => return Value::Condition(format!("Reader error: {}", e)),
             // `lines` does not include \n,  but \n is part of the whitespace given to the reader
-            // (and is important for reading comments) so we will push a newline as well 
-            Some(Ok(line)) => { input_buffer.push_str(&line); input_buffer.push_str("\n"); },
+            // (and is important for reading comments) so we will push a newline as well
+            Some(Ok(line)) => {
+                input_buffer.push_str(&line);
+                input_buffer.push_str("\n");
+            }
             None => {
                 return Value::Condition(String::from("Tried to read empty stream; unexpected EOF"))
             }

--- a/src/rust_core.rs
+++ b/src/rust_core.rs
@@ -35,6 +35,18 @@ pub use self::rand::*;
 pub(crate) mod rand_int;
 pub use self::rand_int::*;
 
+pub(crate) mod lt;
+pub use self::lt::*;
+
+pub(crate) mod lte;
+pub use self::lte::*;
+
+pub(crate) mod gt;
+pub use self::gt::*;
+
+pub(crate) mod gte;
+pub use self::gte::*;
+
 // string
 pub(crate) mod str;
 pub use self::str::*;

--- a/src/rust_core/gt.rs
+++ b/src/rust_core/gt.rs
@@ -1,0 +1,77 @@
+use crate::error_message;
+use crate::ifn::IFn;
+use crate::value::{ToValue, Value};
+use std::rc::Rc;
+
+/// (gt x y)
+/// x > y
+#[derive(Debug, Clone)]
+pub struct GtFn {}
+impl ToValue for GtFn {
+    fn to_value(&self) -> Value {
+        Value::IFn(Rc::new(self.clone()))
+    }
+}
+impl IFn for GtFn {
+    fn invoke(&self, args: Vec<Rc<Value>>) -> Value {
+        if args.len() != 2 {
+            return error_message::wrong_arg_count(2, args.len());
+        }
+        match args.get(0).unwrap().to_value() {
+            Value::I32(a) => match args.get(1).unwrap().to_value() {
+                Value::I32(b) => Value::Boolean(a > b),
+                Value::F64(b) => Value::Boolean(a > b as i32),
+                b_ => Value::Condition(format!(
+                    // TODO: what error message should be returned regarding using typetags?
+                    "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
+                    b_.type_tag()
+                )),
+            },
+            Value::F64(a) => match args.get(0).unwrap().to_value() {
+                Value::I32(b) => Value::Boolean(a > b as f64),
+                Value::F64(b) => Value::Boolean(a > b),
+                b_ => Value::Condition(format!(
+                    // TODO: what error message should be returned regarding using typetags?
+                    "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
+                    b_.type_tag()
+                )),
+            },
+            a_ => Value::Condition(format!(
+                // TODO: what error message should be returned regarding using typetags?
+                "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
+                a_.type_tag()
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod gt_tests {
+        use crate::ifn::IFn;
+        use crate::rust_core::GtFn;
+        use crate::value::Value;
+        use std::rc::Rc;
+
+        #[test]
+        fn one_is_greater_than_zero() {
+            let gt = GtFn {};
+            let args = vec![Rc::new(Value::I32(1)), Rc::new(Value::I32(0))];
+            assert_eq!(Value::Boolean(true), gt.invoke(args));
+        }
+
+        #[test]
+        fn one_is_not_greater_than_one() {
+            let gt = GtFn {};
+            let args = vec![Rc::new(Value::I32(1)), Rc::new(Value::I32(1))];
+            assert_eq!(Value::Boolean(false), gt.invoke(args));
+        }
+
+        #[test]
+        fn one_is_not_greater_than_one_and_fractions() {
+            let gt = GtFn {};
+            let args = vec![Rc::new(Value::I32(1)), Rc::new(Value::F64(1.00001))];
+            assert_eq!(Value::Boolean(false), gt.invoke(args));
+        }
+    }
+}

--- a/src/rust_core/gte.rs
+++ b/src/rust_core/gte.rs
@@ -1,0 +1,77 @@
+use crate::error_message;
+use crate::ifn::IFn;
+use crate::value::{ToValue, Value};
+use std::rc::Rc;
+
+/// (gte x y)
+/// x >= y
+#[derive(Debug, Clone)]
+pub struct GteFn {}
+impl ToValue for GteFn {
+    fn to_value(&self) -> Value {
+        Value::IFn(Rc::new(self.clone()))
+    }
+}
+impl IFn for GteFn {
+    fn invoke(&self, args: Vec<Rc<Value>>) -> Value {
+        if args.len() != 2 {
+            return error_message::wrong_arg_count(2, args.len());
+        }
+        match args.get(0).unwrap().to_value() {
+            Value::I32(a) => match args.get(1).unwrap().to_value() {
+                Value::I32(b) => Value::Boolean(a >= b),
+                Value::F64(b) => Value::Boolean(a as f64 >= b),
+                b_ => Value::Condition(format!(
+                    // TODO: what error message should be returned regarding using typetags?
+                    "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
+                    b_.type_tag()
+                )),
+            },
+            Value::F64(a) => match args.get(0).unwrap().to_value() {
+                Value::I32(b) => Value::Boolean(a >= b as f64),
+                Value::F64(b) => Value::Boolean(a >= b),
+                b_ => Value::Condition(format!(
+                    // TODO: what error message should be returned regarding using typetags?
+                    "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
+                    b_.type_tag()
+                )),
+            },
+            a_ => Value::Condition(format!(
+                // TODO: what error message should be returned regarding using typetags?
+                "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
+                a_.type_tag()
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod gte_tests {
+        use crate::ifn::IFn;
+        use crate::rust_core::GteFn;
+        use crate::value::Value;
+        use std::rc::Rc;
+
+        #[test]
+        fn one_is_greater_than_zero() {
+            let gte = GteFn {};
+            let args = vec![Rc::new(Value::I32(1)), Rc::new(Value::I32(0))];
+            assert_eq!(Value::Boolean(true), gte.invoke(args));
+        }
+
+        #[test]
+        fn one_is_gte_than_one() {
+            let gte = GteFn {};
+            let args = vec![Rc::new(Value::I32(1)), Rc::new(Value::I32(1))];
+            assert_eq!(Value::Boolean(true), gte.invoke(args));
+        }
+
+        #[test]
+        fn one_is_not_gte_than_one_and_fractions() {
+            let gte = GteFn {};
+            let args = vec![Rc::new(Value::I32(1)), Rc::new(Value::F64(1.00001))];
+            assert_eq!(Value::Boolean(false), gte.invoke(args));
+        }
+    }
+}

--- a/src/rust_core/lt.rs
+++ b/src/rust_core/lt.rs
@@ -1,0 +1,77 @@
+use crate::error_message;
+use crate::ifn::IFn;
+use crate::value::{ToValue, Value};
+use std::rc::Rc;
+
+/// (lt x y)
+/// x < y
+#[derive(Debug, Clone)]
+pub struct LtFn {}
+impl ToValue for LtFn {
+    fn to_value(&self) -> Value {
+        Value::IFn(Rc::new(self.clone()))
+    }
+}
+impl IFn for LtFn {
+    fn invoke(&self, args: Vec<Rc<Value>>) -> Value {
+        if args.len() != 2 {
+            return error_message::wrong_arg_count(2, args.len());
+        }
+        match args.get(0).unwrap().to_value() {
+            Value::I32(a) => match args.get(1).unwrap().to_value() {
+                Value::I32(b) => Value::Boolean(a < b),
+                Value::F64(b) => Value::Boolean(a < b as i32),
+                b_ => Value::Condition(format!(
+                    // TODO: what error message should be returned regarding using typetags?
+                    "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
+                    b_.type_tag()
+                )),
+            },
+            Value::F64(a) => match args.get(0).unwrap().to_value() {
+                Value::I32(b) => Value::Boolean(a < b as f64),
+                Value::F64(b) => Value::Boolean(a < b),
+                b_ => Value::Condition(format!(
+                    // TODO: what error message should be returned regarding using typetags?
+                    "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
+                    b_.type_tag()
+                )),
+            },
+            a_ => Value::Condition(format!(
+                // TODO: what error message should be returned regarding using typetags?
+                "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
+                a_.type_tag()
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod lt_tests {
+        use crate::ifn::IFn;
+        use crate::rust_core::LtFn;
+        use crate::value::Value;
+        use std::rc::Rc;
+
+        #[test]
+        fn zero_is_less_than_one() {
+            let lt = LtFn {};
+            let args = vec![Rc::new(Value::I32(0)), Rc::new(Value::I32(1))];
+            assert_eq!(Value::Boolean(true), lt.invoke(args));
+        }
+
+        #[test]
+        fn one_is_not_less_than_one() {
+            let lt = LtFn {};
+            let args = vec![Rc::new(Value::I32(1)), Rc::new(Value::I32(1))];
+            assert_eq!(Value::Boolean(false), lt.invoke(args));
+        }
+
+        #[test]
+        fn one_is_less_than_one_and_fractions() {
+            let lt = LtFn {};
+            let args = vec![Rc::new(Value::I32(1)), Rc::new(Value::F64(1.00001))];
+            assert_eq!(Value::Boolean(false), lt.invoke(args));
+        }
+    }
+}

--- a/src/rust_core/lte.rs
+++ b/src/rust_core/lte.rs
@@ -1,0 +1,77 @@
+use crate::error_message;
+use crate::ifn::IFn;
+use crate::value::{ToValue, Value};
+use std::rc::Rc;
+
+/// (lte x y)
+/// x <= y
+#[derive(Debug, Clone)]
+pub struct LteFn {}
+impl ToValue for LteFn {
+    fn to_value(&self) -> Value {
+        Value::IFn(Rc::new(self.clone()))
+    }
+}
+impl IFn for LteFn {
+    fn invoke(&self, args: Vec<Rc<Value>>) -> Value {
+        if args.len() != 2 {
+            return error_message::wrong_arg_count(2, args.len());
+        }
+        match args.get(0).unwrap().to_value() {
+            Value::I32(a) => match args.get(1).unwrap().to_value() {
+                Value::I32(b) => Value::Boolean(a <= b),
+                Value::F64(b) => Value::Boolean(a <= b as i32),
+                b_ => Value::Condition(format!(
+                    // TODO: what error message should be returned regarding using typetags?
+                    "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
+                    b_.type_tag()
+                )),
+            },
+            Value::F64(a) => match args.get(0).unwrap().to_value() {
+                Value::I32(b) => Value::Boolean(a <= b as f64),
+                Value::F64(b) => Value::Boolean(a <= b),
+                b_ => Value::Condition(format!(
+                    // TODO: what error message should be returned regarding using typetags?
+                    "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
+                    b_.type_tag()
+                )),
+            },
+            a_ => Value::Condition(format!(
+                // TODO: what error message should be returned regarding using typetags?
+                "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
+                a_.type_tag()
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod lte_tests {
+        use crate::ifn::IFn;
+        use crate::rust_core::LteFn;
+        use crate::value::Value;
+        use std::rc::Rc;
+
+        #[test]
+        fn zero_is_lte_than_zero() {
+            let lte = LteFn {};
+            let args = vec![Rc::new(Value::I32(0)), Rc::new(Value::I32(1))];
+            assert_eq!(Value::Boolean(true), lte.invoke(args));
+        }
+
+        #[test]
+        fn one_is_lte_than_one() {
+            let lte = LteFn {};
+            let args = vec![Rc::new(Value::I32(1)), Rc::new(Value::I32(1))];
+            assert_eq!(Value::Boolean(true), lte.invoke(args));
+        }
+
+        #[test]
+        fn one_is_lte_than_one_and_fractions() {
+            let lte = LteFn {};
+            let args = vec![Rc::new(Value::I32(1)), Rc::new(Value::F64(1.00001))];
+            assert_eq!(Value::Boolean(true), lte.invoke(args));
+        }
+    }
+}

--- a/src/rust_core/refer.rs
+++ b/src/rust_core/refer.rs
@@ -2,7 +2,7 @@ use crate::environment::Environment;
 use crate::error_message;
 use crate::ifn::IFn;
 use crate::keyword::Keyword;
-use crate::persistent_vector::{ToPersistentVectorIter};
+use crate::persistent_vector::ToPersistentVectorIter;
 use crate::symbol::Symbol;
 use crate::type_tag::TypeTag;
 use crate::util::IsOdd;


### PR DESCRIPTION
includes language necessities lt, gt, gte, lte, the clojure.lang.Numbers equivalients interface wise

```clojure
clojure.core=> (def < clojure.interop/lt)
<
clojure.core=> (def <= clojure.interop/lte)
<=
clojure.core=> (< 1 2)
true
clojure.core=> (<= 1 1)
true
clojure.core=> (<= 1 0)
false
```