### PR TITLE
proposal for refactoring special form code structure, example with fn*

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -307,10 +307,17 @@ impl Environment {
         let ns_macro = rust_core::NsMacro::new(Rc::clone(&environment));
         let load_file_fn = rust_core::LoadFileFn::new(Rc::clone(&environment));
         let refer_fn = rust_core::ReferFn::new(Rc::clone(&environment));
+
+        // special forms
+        let fn_star = Value::FnStarSpecialForm {};
+
         // @TODO after we merge this with all the other commits we have,
         //       just change all the `insert`s here to use insert_in_namespace
         //       I prefer explicity and the non-dependence-on-environmental-factors
         environment.change_or_create_namespace(&Symbol::intern("clojure.core"));
+
+        // special forms
+        //environment.insert(Symbol::intern("fn**"), fn_star.to_rc_value());
 
         environment.insert(Symbol::intern("+"), add_fn.to_rc_value());
         environment.insert(Symbol::intern("-"), subtract_fn.to_rc_value());
@@ -323,6 +330,7 @@ impl Environment {
         environment.insert(Symbol::intern("quote"), quote_macro.to_rc_value());
         environment.insert(Symbol::intern("def"), def_macro.to_rc_value());
         environment.insert(Symbol::intern("fn"), fn_macro.to_rc_value());
+        environment.insert(Symbol::intern("fn*"), fn_star.to_rc_value());
         environment.insert(Symbol::intern("defmacro"), defmacro_macro.to_rc_value());
         environment.insert(Symbol::intern("eval"), eval_fn.to_rc_value());
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -148,7 +148,7 @@ fn is_period_char(chr: char) -> bool {
 ///
 /// Clojure defines a whitespace as either a comma or an unicode whitespace.
 fn is_clojure_whitespace(c: char) -> bool {
-    c.is_whitespace() || c == ',' 
+    c.is_whitespace() || c == ','
 }
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //     End predicates
@@ -169,16 +169,16 @@ fn consume_clojure_whitespaces_parser(input: &str) -> IResult<&str, ()> {
 
     named!(whitespace_parser<&str,()>,
            value!((),
-               many0!(alt!(comment_parser | 
+               many0!(alt!(comment_parser |
                            take_while1!(is_clojure_whitespace))))
     );
 
     named!(no_whitespace_parser<&str,()>, value!((),tag!("")));
 
-    // @TODO rename / check that all parsers are consistent? 
+    // @TODO rename / check that all parsers are consistent?
     named!(parser<&str,()>,
            // Because 'whitespace_parser' loops, we cannot include the case where there's no whitespace at all in
-           // its definition -- nom wouldn't allow it, as it would loop forever consuming no whitespace 
+           // its definition -- nom wouldn't allow it, as it would loop forever consuming no whitespace
            // So instead, we eat up all the whitespace first, and then use the no_whitespace_parser as our sort-of
            // base-case after
            alt!(whitespace_parser | no_whitespace_parser)
@@ -560,12 +560,15 @@ pub fn read<R: BufRead>(reader: &mut R) -> Value {
     // loop over and ask for more lines, accumulating them in input_buffer until we can read
     loop {
         let maybe_line = reader.by_ref().lines().next();
-        
+
         match maybe_line {
             Some(Err(e)) => return Value::Condition(format!("Reader error: {}", e)),
             // `lines` does not include \n,  but \n is part of the whitespace given to the reader
-            // (and is important for reading comments) so we will push a newline as well 
-            Some(Ok(line)) => { input_buffer.push_str(&line); input_buffer.push_str("\n"); },
+            // (and is important for reading comments) so we will push a newline as well
+            Some(Ok(line)) => {
+                input_buffer.push_str(&line);
+                input_buffer.push_str("\n");
+            }
             None => {
                 return Value::Condition(String::from("Tried to read empty stream; unexpected EOF"))
             }

--- a/src/rust_core.rs
+++ b/src/rust_core.rs
@@ -1,6 +1,10 @@
 // This module will hold core function and macro primitives that aren't special cases
 // (like the quote macro, or let), and can't be implemented in clojure itself
 
+// special forms
+pub(crate) mod special_form;
+pub use self::special_form::*;
+
 // language core functions
 pub(crate) mod eval;
 pub use self::eval::*;

--- a/src/rust_core/refer.rs
+++ b/src/rust_core/refer.rs
@@ -2,7 +2,7 @@ use crate::environment::Environment;
 use crate::error_message;
 use crate::ifn::IFn;
 use crate::keyword::Keyword;
-use crate::persistent_vector::{ToPersistentVectorIter};
+use crate::persistent_vector::ToPersistentVectorIter;
 use crate::symbol::Symbol;
 use crate::type_tag::TypeTag;
 use crate::util::IsOdd;

--- a/src/rust_core/special_form.rs
+++ b/src/rust_core/special_form.rs
@@ -1,0 +1,35 @@
+/*
+
+Clojure Special Forms
+
+(pprint (keys (. clojure.lang.Compiler specials)))
+
+TODO: &
+TODO: monitor-exit
+TODO: case*
+TODO: try
+TODO: reify*
+TODO: finally
+TODO: loop*
+TODO: do
+TODO: letfn*
+TODO: if
+TODO: clojure.core/import*
+TODO: new
+TODO: deftype*
+TODO: let*
+- fn*
+TODO: recur
+TODO: set!
+TODO: .
+TODO: var
+TODO: quote
+TODO: catch
+TODO: throw
+TODO: monitor-enter
+TODO: def
+
+*/
+
+pub(crate) mod fn_star;
+pub use self::fn_star::*;

--- a/src/rust_core/special_form/fn_star.rs
+++ b/src/rust_core/special_form/fn_star.rs
@@ -1,0 +1,98 @@
+use crate::environment::Environment;
+use crate::ifn::IFn;
+use crate::value::{Evaluable, ToValue, Value};
+use std::rc::Rc;
+
+use crate::iterable::Iterable;
+use crate::persistent_list::{PersistentList, ToPersistentList};
+use crate::persistent_vector::PersistentVector;
+use crate::protocol::ProtocolCastable;
+use crate::symbol::Symbol;
+use crate::type_tag::TypeTag;
+use crate::{error_message, lambda};
+
+/// Special Form implementation
+/// (fn* [& fdecl])
+/// i.e. (fn* [a] (println "hello " a))
+/// supports also other possible forms met in clojure.core, but does nothing
+/// https://stackoverflow.com/questions/7552632/what-does-static-do-in-clojure
+/// possible deprecation, needs to be inspected
+/// (fn* let [a b c] ...)
+/// (fn* ^Static let [ ] ...)
+pub fn FnStar(environment: &Rc<Environment>, args: &Rc<PersistentList>) -> Option<Rc<Value>> {
+    let arg_rc_values = PersistentList::iter(args)
+        .map(|rc_arg| rc_arg)
+        .collect::<Vec<Rc<Value>>>();
+
+    if arg_rc_values.is_empty() {
+        return Some(Rc::new(Value::Condition(format!(
+            "Wrong number of arguments (Given: {}, Expect: >=1",
+            arg_rc_values.len()
+        ))));
+    }
+
+    // skip optionally deprecated forms
+    let mut arg_index = 0;
+    arg_index = match arg_rc_values.get(0).unwrap().to_value() {
+        Value::Symbol(_) => arg_index + 1,
+        _ => arg_index,
+    };
+    if args.len() > 1 {
+        arg_index = match arg_rc_values.get(1).unwrap().to_value() {
+            Value::Symbol(_) => arg_index + 1,
+            _ => arg_index,
+        };
+    }
+
+    if arg_index > args.len() - 1 {
+        return Some(Rc::new(Value::Condition(std::string::String::from(
+            "help: (fn* meta-kw? symbol-name? argv body)",
+        ))));
+    }
+
+    let fn_args = arg_rc_values.get(arg_index as usize).unwrap();
+
+    match &**fn_args {
+        Value::PersistentVector(PersistentVector { vals }) => {
+            let mut arg_syms_vec = vec![];
+            let enclosing_environment =
+                Rc::new(Environment::new_local_environment(Rc::clone(&environment)));
+            for val in vals.iter() {
+                if let Value::Symbol(sym) = &**val {
+                    arg_syms_vec.push(sym.clone());
+                }
+            }
+
+            let fn_body =
+                // (fn [x y] ) -> nil 
+                if (arg_rc_values.len()- arg_index as usize) <= 1 {
+                    Rc::new(Value::Nil)
+                    // (fn [x y] expr) -> expr 
+                } else if arg_rc_values.len() == 2 {
+                    Rc::clone(arg_rc_values.get((arg_index  + 1) as usize).unwrap())
+                    // (fn [x y] expr1 expr2 expr3) -> (do expr1 expr2 expr3) 
+                } else {
+                    // (&[expr1 expr2 expr3] 
+                    let body_exprs = arg_rc_values.get(1..).unwrap();
+                    // vec![do]
+                    let mut do_body = vec![Symbol::intern("do").to_rc_value()];
+                    // vec![do expr1 expr2 expr3]
+                    do_body.extend_from_slice(body_exprs);
+                    // (do expr1 expr2 expr3) 
+                    do_body.into_list().to_rc_value()
+                };
+
+            Some(Rc::new(
+                lambda::Fn {
+                    body: fn_body,
+                    enclosing_environment,
+                    arg_syms: arg_syms_vec,
+                }
+                .to_value(),
+            ))
+        }
+        _ => Some(Rc::new(Value::Condition(std::string::String::from(
+            "help: (fn* meta-kw? symbol-name? argv body)",
+        )))),
+    }
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -56,6 +56,7 @@ pub enum Value {
     DefmacroMacro,
     DefMacro,
     FnMacro,
+    FnStarSpecialForm,
     LetMacro,
     IfMacro,
 
@@ -63,6 +64,7 @@ pub enum Value {
     Nil,
     Pattern(regex::Regex),
 }
+use crate::rust_core::FnStar;
 use crate::value::Value::*;
 
 impl PartialEq for Value {
@@ -106,6 +108,7 @@ enum ValueHash {
     DefmacroMacro,
     DefMacro,
     FnMacro,
+    FnStarSpecialForm,
     IfMacro,
     LetMacro,
     Nil,
@@ -140,6 +143,7 @@ impl Hash for Value {
             DefmacroMacro => ValueHash::DefmacroMacro.hash(state),
             DefMacro => ValueHash::DefMacro.hash(state),
             FnMacro => ValueHash::FnMacro.hash(state),
+            FnStarSpecialForm => ValueHash::FnStarSpecialForm.hash(state),
             LetMacro => ValueHash::LetMacro.hash(state),
             IfMacro => ValueHash::IfMacro.hash(state),
 
@@ -170,6 +174,7 @@ impl fmt::Display for Value {
             DefMacro => std::string::String::from("#macro[def*]"),
             DefmacroMacro => std::string::String::from("#macro[defmacro*]"),
             FnMacro => std::string::String::from("#macro[fn*]"),
+            FnStarSpecialForm => std::string::String::from("#specialform[fn*]"),
             IfMacro => std::string::String::from("#macro[if*]"),
             LetMacro => std::string::String::from("#macro[let*]"),
             Value::String(string) => string.clone(),
@@ -217,6 +222,7 @@ impl Value {
             Value::DefmacroMacro => TypeTag::Macro,
             Value::LetMacro => TypeTag::Macro,
             Value::FnMacro => TypeTag::Macro,
+            Value::FnStarSpecialForm => TypeTag::Macro,
             Value::IfMacro => TypeTag::Macro,
             Value::String(_) => TypeTag::String,
             Value::Nil => TypeTag::Nil,
@@ -529,6 +535,7 @@ impl Value {
                     )
                 }
             }
+            Value::FnStarSpecialForm => FnStar(environment, args),
             //
             // If we're not a valid IFn
             //


### PR DESCRIPTION
Proposal to refactor special forms to own modules for easier code navigation (extract implementation to different module)

This version introduces special form `fn*`, which is interface wise compatible with clojure internals