### PR TITLE
make it possible to include clojurers as a library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,34 @@
+#[macro_use]
+extern crate nom;
+extern crate itertools;
+
+#[macro_use]
+pub mod persistent_list_map;
+#[macro_use]
+pub mod persistent_list;
+#[macro_use]
+pub mod protocol;
+#[macro_use]
+pub mod symbol;
+#[macro_use]
+pub mod var;
+pub mod clojure_std;
+pub mod clojure_string;
+pub mod environment;
+pub mod error_message;
+pub mod ifn;
+pub mod iterable;
+pub mod keyword;
+pub mod lambda;
+pub mod maps;
+pub mod namespace;
+pub mod persistent_vector;
+pub mod protocols;
+pub mod reader;
+pub mod repl;
+pub mod rust_core;
+pub mod traits;
+pub mod type_tag;
+pub mod user_action;
+pub mod util;
+pub mod value;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,15 +23,16 @@ mod lambda;
 mod maps;
 mod namespace;
 mod persistent_vector;
+mod protocols;
 mod reader;
 mod repl;
 mod rust_core;
+mod traits;
 mod type_tag;
 mod user_action;
 mod util;
 mod value;
-mod protocols;
-mod traits;
+
 fn main() {
     let cli_args: user_action::Action = user_action::parse_args(std::env::args().collect());
 


### PR DESCRIPTION
includes a lib.rs that provides public access to modules, for using clojurers as a crate.

cargo.toml

```toml
[dependencies]
rust_clojure = { git = "https://github.com/clojure-rs/ClojureRS" }
```

main.rs
```rust 
extern crate rust_clojure;
use rust_clojure::repl::*;
...

let repl = Repl::default();
```