### PR TITLE
fix: docs for reader::first_char now no longer incorrectly state `None` may be returned

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -55,9 +55,6 @@ use std::io::BufRead;
 
 /// Returns the first character of a string slice.
 ///
-/// If `input` is not empty, then its first char will be returned. Otherwise,
-/// `None` is returned.
-///
 /// # Panics
 ///
 /// This function will panic if `input` is an empty string slice.


### PR DESCRIPTION
Given `first_char`'s return type is `char`, not `Option<char>`, `Option<_>::None` can never be returned.

**Edit**: I license my contributions under the Apache-2.0 license ([which is the current license of this work](https://github.com/clojure-rs/ClojureRS/blob/69565b2678212704dd776e807de58fa7b61b23cc/LICENSE)).