### PR TITLE
add `clojure.core/map` to core environment

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -498,6 +498,7 @@ impl Environment {
         environment.insert(Symbol::intern("nth"), nth_fn.to_rc_value());
         environment.insert(Symbol::intern("assoc"), assoc_fn.to_rc_value());
         environment.insert(Symbol::intern("get"), get_fn.to_rc_value());
+        environment.insert(Symbol::intern("map"), map_fn.to_rc_value());
         environment.insert(Symbol::intern("concat"), concat_fn.to_rc_value());
         environment.insert(Symbol::intern("more"), more_fn.to_rc_value());
         environment.insert(Symbol::intern("first"), first_fn.to_rc_value());


### PR DESCRIPTION
Prior to this PR:
```bash
cargo run -- -e '(prn [:a])'
[:a]
nil
```
```bash
cargo run -- -e '(map prn [:a])'
#Condition["Execution Error: clojure.lang.Condition cannot be cast to clojure.lang.IFn"]
```

As of this PR:
```bash
cargo run -- -e '(map prn [:a])'
:a
(nil)
```