### PR TITLE
Resolved bug when calling a function with vararg

### DIFF
--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -1,4 +1,3 @@
-use std::env::var;
 use crate::environment::Environment;
 use crate::ifn::IFn;
 use crate::persistent_list::ToPersistentList;
@@ -69,3 +68,92 @@ impl IFn for Fn {
         self.body.eval(local_environment)
     }
 }
+
+///
+/// Tests
+///
+
+#[cfg(test)]
+mod tests {
+    use std::rc::Rc;
+    use crate::environment::Environment;
+    use crate::ifn::IFn;
+    use crate::lambda;
+    use crate::symbol::Symbol;
+    use crate::value::Value;
+
+    #[test]
+    fn test_only_vararg() {
+        // (defn func [& vararg] "Works")
+        let func = lambda::Fn {
+            body: Rc::new(Value::String(String::from("Works"))),
+            enclosing_environment: Rc::new(Environment::new_local_environment(Environment::clojure_core_environment())),
+            arg_syms: vec![Symbol::intern("&"), Symbol::intern("varargs")],
+        };
+
+        let val = func.invoke(vec![]); // (func)
+        assert_eq!(val, Value::String("Works".to_string()));
+
+        let val = func.invoke(vec![Rc::new(Value::I32(1_i32))]); // (func 1)
+        assert_eq!(val, Value::String("Works".to_string()));
+
+        let val = func.invoke(vec![    //
+            Rc::new(Value::I32(1_i32)),      //  (func 1 2)
+            Rc::new(Value::I32(2_i32)),      //
+        ]);                                        //
+        assert_eq!(val, Value::String("Works".to_string()));
+    }
+
+    #[test]
+    fn test_vararg_one() {
+        // (defn func [x & vararg] "Works")
+        let func = lambda::Fn {
+            body: Rc::new(Value::String(String::from("Works"))),
+            enclosing_environment: Rc::new(Environment::new_local_environment(Environment::clojure_core_environment())),
+            arg_syms: vec![Symbol::intern("x"), Symbol::intern("&"), Symbol::intern("varargs")],
+        };
+
+        let val = func.invoke(vec![]); // (func)
+        assert_eq!(val, Value::Condition("Wrong number of arguments given to function (Given: 0, Expected: 1 or more)".to_string()));
+
+        let val = func.invoke(vec![Rc::new(Value::I32(1_i32))]); // (func 1)
+        assert_eq!(val, Value::String("Works".to_string()));
+
+        let val = func.invoke(vec![                                    //  (func 1 2)
+                                       Rc::new(Value::I32(1_i32)),
+                                       Rc::new(Value::I32(2_i32)),
+        ]);
+        assert_eq!(val, Value::String("Works".to_string()));
+    }
+
+    #[test]
+    fn test_vararg_two() {
+        // (defn func [x y & vararg] "Works")
+        let func = lambda::Fn {
+            body: Rc::new(Value::String(String::from("Works"))),
+            enclosing_environment: Rc::new(Environment::new_local_environment(Environment::clojure_core_environment())),
+            arg_syms: vec![Symbol::intern("x"), Symbol::intern("y"),
+                           Symbol::intern("&"), Symbol::intern("varargs")],
+        };
+
+        let val = func.invoke(vec![]); // (func)
+        assert_eq!(val, Value::Condition("Wrong number of arguments given to function (Given: 0, Expected: 2 or more)".to_string()));
+
+        let val = func.invoke(vec![Rc::new(Value::I32(1_i32))]); // (func 1)
+        assert_eq!(val, Value::Condition("Wrong number of arguments given to function (Given: 1, Expected: 2 or more)".to_string()));
+
+        let val = func.invoke(vec![ //  (func 1 2)
+            Rc::new(Value::I32(1_i32)),
+            Rc::new(Value::I32(2_i32)),
+        ]);
+        assert_eq!(val, Value::String("Works".to_string()));
+
+        let val = func.invoke(vec![ //  (func 1 2 "vararg here")
+            Rc::new(Value::I32(1_i32)),
+            Rc::new(Value::I32(2_i32)),
+            Rc::new(Value::String(String::from("vararg here"))),
+        ]);
+        assert_eq!(val, Value::String("Works".to_string()));
+    }
+}
+

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -1,3 +1,4 @@
+use std::env::var;
 use crate::environment::Environment;
 use crate::ifn::IFn;
 use crate::persistent_list::ToPersistentList;
@@ -36,6 +37,13 @@ impl IFn for Fn {
             }
         }
 
+        if var_args && args.len() < argc -  2 {
+            return Value::Condition(format!(
+                "Wrong number of arguments given to function (Given: {}, Expected: {} or more)",
+                args.len(),
+                argc - 2
+            ));
+        }
         if !var_args && args.len() != argc {
             return Value::Condition(format!(
                 "Wrong number of arguments given to function (Given: {}, Expected: {})",


### PR DESCRIPTION
There was a bug when invoking funcs with varargs that i fixed:

If there wasn't a var arg the cheker for the correct amount of args provided worked perfectly fine:
```clojure
(defn testfunc [x] "Works")

(testfunc 1) ;=> "Works"
(testfunc) ;=> ERROR! As expected :)
(testfunc 1 2) ;=> ERROR! As expected :)
```
However if there was a vararg even if the first arguments weren't provided it would run:

```clojure
(defn testvararg1 [& var] "First Works")
(defn testvararg2 [x & var] "Second Works")
(defn testvararg3 [x y & var] "Third Works")


(testvararg1) ;=> "First Works"
(testvararg1 1 "hi" [0]) ;=> "First Works"

(testvararg2) ;=> "Second Works" (IT SHOULD THROW AN ERROR: THE FIRST 'x' ARG ISN'T PROVIDED!)
(testvararg2 1 "hi" [0]) ;=> "Second Works"


(testvararg3) ;=> "Third Works" (IT SHOULD THROW AN ERROR: THE FIRST 'x' AND SECOND 'y' ARGS WERE NTO PROVIDED!)
(testvararg3 1) ;=> "Third Works" (IT SHOULD THROW AN ERROR: THE SECOND 'y' ARG ISN'T PROVIDED!)
(testvararg3 1 2 "hi" [0]) ;=> "Third Works"
```
I fixed this with the following check:
```rust
impl IFn for Fn {
    fn invoke(&self, args: Vec<Rc<Value>>) -> Value {

        //...

        if var_args && args.len() < argc -  2 {
            return Value::Condition(format!(
                "Wrong number of arguments given to function (Given: {}, Expected: {} or more)",
                args.len(),
                argc - 2
            ));
        }

        // THE CHECK THAT WE HAD BEFORE STAYS
        if !var_args && args.len() != argc {
            return Value::Condition(format!(
                "Wrong number of arguments given to function (Given: {}, Expected: {})",
                args.len(),
                argc
            ));
        }

        //...
    }
}
```

I also wrote about this in the discord https://discord.com/channels/703549047901913189/865306224198811658/1097175533332222133